### PR TITLE
Typing issue fix & logging in FirstInstance

### DIFF
--- a/commit-based-cipm/bundles/fi/org.splevo.jamopp.diffing/src/org/splevo/jamopp/diffing/diff/JaMoPPDiffBuilder.java
+++ b/commit-based-cipm/bundles/fi/org.splevo.jamopp.diffing/src/org/splevo/jamopp/diffing/diff/JaMoPPDiffBuilder.java
@@ -220,7 +220,7 @@ public class JaMoPPDiffBuilder extends DiffBuilder {
             return match;
         } else if (parentObject instanceof Constructor) {
             return match;
-        } else if (parentObject instanceof Package) {
+        } else if (parentObject instanceof org.emftext.language.java.containers.Package) {
             return match;
         } else if (parentObject instanceof Enumeration) {
             return match;


### PR DESCRIPTION
About "Fix typing issue": Fixed a type-check checking for the wrong type.

About logging commits: Added an additional logger to each respective class to provide more details about the test runs over the console. Desired loggers can be enabled by uncommenting them in the abstract unit tests. Enabling too many of them and/or not filtering their output by level can lead to memory issues.

Both commits are placed in the same pull request to avoid possible conflicts during integration, due to JaMoPPDiffBuilder receiving its fix first and then its more detailed logger (which caused line numbers to change).