### PR TITLE
Add entry for polygot in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ tmp/
 
 # oh-my-zsh gradle plugin
 .gradletasknamecache
+
+# polygot
+*.polyglot.META-INF


### PR DESCRIPTION
Added an entry into the .gitignore file to ignore the irrelevant ".polyglot.META-INF" files that could be produced while building the project.