### PR TITLE
Fix clean.bat

### DIFF
--- a/scripts/clean.bat
+++ b/scripts/clean.bat
@@ -2,9 +2,6 @@
 cd Vitruv
 git stash --include-untracked
 cd ..
-cd Palladio-ReverseEngineering-SoMoX-JaMoPP
-git stash --include-untracked
-cd ..
 git submodule deinit -f --all
 
 :: Clean all ignored files.


### PR DESCRIPTION
Remove the part about the former submodule "Palladio-ReverseEngineering-SoMoX-JaMoPP" from clean.bat, in order to stop it from going backward twice (due to failing to visit the said submodule's folder).